### PR TITLE
Adds composer.json for composer based installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+ {
+     "name": "revuls/slim-mvc",
+     "type": "library",
+     "description": "MVC for the PHP microframework Slim",
+     "keywords": ["microframework","rest","router", "mvc"],
+     "homepage": "https://github.com/revuls/SlimMVC",
+     "license": "MIT",
+     "authors": [
+         {
+             "name": "revuls"
+         }
+     ],
+     "require": {
+         "php": ">=5.3.0",
+         "slim/slim": "2.*",
+         "slim/extras": "2.*"
+     },
+     "autoload": {
+         "psr-0": { "slim-mvc": "." }
+     }
+ }


### PR DESCRIPTION
For seamless use, composer requires the use of version number tags in the repo, in the format of #.#.#
